### PR TITLE
escape the_field('slideshow') on landing page by using wp_kses_post

### DIFF
--- a/landing_page.php
+++ b/landing_page.php
@@ -14,7 +14,7 @@ Template Name: Startseite
 		<h4 class="logoDescription"><?php bloginfo('description'); ?></h4>
 	</header>
 	<?php the_post(); ?>
-	<?php the_field('slideshow'); ?>
+	<?php echo wp_kses_post( get_field('slideshow') ); ?>
 	<article class="pageStyle">
 		<div class="xColumnView landingPageText">
 			<div class="twoColumnViewItem">


### PR DESCRIPTION
Due to ACF security update: https://www.advancedcustomfields.com/blog/acf-6-2-5-security-release/